### PR TITLE
Mono-space font for chords block

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -292,6 +292,7 @@
 .audio_row_chords_block {
     white-space: pre-wrap;
     padding-left: 30px;
+    font-family: monospace;
 }
 
 .audio_row_video_block .close, .audio_row_chords_block .close {


### PR DESCRIPTION
Mono-space font would fit better for chords block. It may be not that critical for chords, but often there are tabs instead of chords and in this case default proportional font doesn't work well:

![image](https://cloud.githubusercontent.com/assets/846611/18811949/87d8cec2-82cb-11e6-88f4-f224684d3804.png)

with mono-space font it looks much better:

![image](https://cloud.githubusercontent.com/assets/846611/18811943/3fa53604-82cb-11e6-9691-1726b1d64b11.png)
